### PR TITLE
Add ECT metric implementation

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -253,6 +253,14 @@ Mean Average Cosine Similarity (MAC), presented in the paper "*Black is to*
 *criminals caucasian is to police: Detecting and removing multiclass bias*
 *in word embeddings*".
 
+ECT
+---
+
+The Embedding Coherence Test, presented in "Attenuating Bias in Word vectors"
+calculates the average target group vectors, measures the cosine similarity of each
+to a list of attribute words and calculates the correlation of the resulting
+similarity lists.
+
 
 Relevant Papers
 ===============
@@ -268,6 +276,7 @@ Measurements and Case Studies
 - `Caliskan, A., Bryson, J. J., & Narayanan, A. (2017). Semantics derived automatically from language corpora contain human-like biases. Science, 356(6334), 183-186. <http://www.cs.bath.ac.uk/~jjb/ftp/CaliskanSemantics-Arxiv.pdf>`_.
 - `Garg, N., Schiebinger, L., Jurafsky, D., & Zou, J. (2018). Word embeddings quantify 100 years of gender and ethnic stereotypes. Proceedings of the National Academy of Sciences, 115(16), E3635-E3644. <https://www.pnas.org/content/pnas/115/16/E3635.full.pdf>`_.
 - `Sweeney, C., & Najafian, M. (2019, July). A Transparent Framework for Evaluating Unintended Demographic Bias in Word Embeddings. In Proceedings of the 57th Annual Meeting of the Association for Computational Linguistics (pp. 1662-1667). <https://www.aclweb.org/anthology/P19-1162.pdf>`_.
+- `Dev, S., & Phillips, J. (2019, April). Attenuating Bias in Word vectors. In Proceedings of the 22nd International Conference on Artificial Intelligence and Statistics (pp. 879-887). <http://proceedings.mlr.press/v89/dev19a.html>`_.
 
 
 Bias Mitigation

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -65,6 +65,15 @@ RNSB
 
    RNSB
 
+ECT
+=====
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   ECT
+
 
 Dataloaders
 ===========

--- a/wefe/__init__.py
+++ b/wefe/__init__.py
@@ -5,6 +5,7 @@ from .metrics.WEAT import WEAT
 from .metrics.RND import RND
 from .metrics.RNSB import RNSB
 from .metrics.MAC import MAC
+from .metrics.ECT import ECT
 from .datasets import load_bingliu, fetch_debias_multiclass, fetch_debiaswe, fetch_eds, load_weat
 from ._version import __version__
 

--- a/wefe/metrics/ECT.py
+++ b/wefe/metrics/ECT.py
@@ -1,0 +1,115 @@
+import numpy as np
+
+from scipy.spatial.distance import cosine
+from scipy.stats import spearmanr
+
+from .base_metric import BaseMetric
+from ..query import Query
+from ..word_embedding_model import WordEmbeddingModel
+
+
+class ECT(BaseMetric):
+    """An implementation of the Embedding Coherence Test.
+
+    The metrics was originally proposed in [1] and implemented in [2].
+
+    The general steps of the test, as defined in [1], are as follows:
+
+    1. Embedd all given target and attribute words with the given embedding model
+    2. Calculate mean vectors for the two sets of target word vectors
+    3. Measure the cosine similarity of the mean target vectors to all of the given attribute words
+    4. Calculate the Spearman r correlation between the resulting two lists of similarities
+    5. Return the correlation value as score of the metric (in the range of -1 to 1); higher is
+       better
+
+
+    References
+    ----------
+    | [1]: Dev, S., & Phillips, J. (2019, April). Attenuating Bias in Word vectors.
+    | [2]: https://github.com/sunipa/Attenuating-Bias-in-Word-Vec
+    """
+    def __init__(self):
+        # The metrics accepts two target sets and a single attribute set
+        metric_template = (2, 1)
+        metric_name = "Embedding Coherence Test"
+        metric_short_name = "ECT"
+
+        super().__init__(metric_template, metric_name, metric_short_name)
+
+    def run_query(
+            self,
+            query: Query,
+            word_embedding: WordEmbeddingModel,
+            lost_vocabulary_threshold: float = 0.2,
+            warn_filtered_words: bool = True):
+        """Runs the given query with the given parameters.
+
+        Parameters
+        ----------
+        query : Query
+            A Query object that contains the target and attribute words for be tested.
+        word_embedding : WordEmbeddingModel
+            A WordEmbeddingModel object that contain certain word embedding pretrained model.
+        lost_vocabulary_threshold : bool, optional
+            Indicates when a test is invalid due the loss of certain amount of words in any word
+            set, by default 0.2
+        warn_filtered_words : bool, optional
+            A flag that indicates if the function will warn about the filtered words, by default
+            False.
+
+        Returns
+        -------
+        dict
+            A dictionary with the query name and the result of the query.
+        """
+
+        # Get word vectors from the specified query
+        embeddings = self._get_embeddings_from_query(
+            query,
+            word_embedding,
+            warn_filtered_words=warn_filtered_words,
+            lost_vocabulary_threshold=lost_vocabulary_threshold)
+
+        # If the lost vocabulary threshold is exceeded, return the default value
+        if embeddings is None:
+            return {"query_name": query.query_name_, "result": np.nan}
+
+        return {
+            "query_name": query.query_name_,
+            "result": self.__calculate_embedding_coherence(
+                list(embeddings[0][0].values()),
+                list(embeddings[0][1].values()),
+                list(embeddings[1][0].values()))}
+
+    def __calculate_embedding_coherence(
+            self,
+            target_set_1: list,
+            target_set_2: list,
+            attribute_set: list) -> float:
+        """Calculate the ECT metric over the given parameters. Return the result.
+
+        Parameters
+        ----------
+        target_set_1 : list
+            The first set of target words.
+        target_set_2 : list
+            The second set of target words.
+        attribute_set : list
+            The set of attribute words.
+
+        Returns
+        -------
+        float
+            The value denoting the Spearman correlation.
+        """
+
+        # Calculate mean vectors for both target vector sets
+        target_means = [np.mean(s, axis=0) for s in (target_set_1, target_set_2)]
+
+        # Measure similarities between mean vecotrs and all attribute words
+        similarities = []
+        for mean_vector in target_means:
+            similarities.append([1 - cosine(mean_vector, a) for a in attribute_set])
+
+        # Calculate similarity correlations
+        return spearmanr(similarities[0], similarities[1]).correlation

--- a/wefe/metrics/__init__.py
+++ b/wefe/metrics/__init__.py
@@ -3,3 +3,4 @@ from .RND import RND
 from .RNSB import RNSB
 from .MAC import MAC
 from .MAC import BaseMetric
+from .ECT import ECT

--- a/wefe/tests/test_metrics.py
+++ b/wefe/tests/test_metrics.py
@@ -4,7 +4,7 @@ from ..utils import load_weat_w2v
 from ..word_embedding_model import WordEmbeddingModel
 from ..datasets.datasets import load_weat
 from ..query import Query
-from ..metrics import WEAT, RND, RNSB, MAC
+from ..metrics import WEAT, RND, RNSB, MAC, ECT
 from sklearn.linear_model import LogisticRegression
 
 
@@ -110,4 +110,18 @@ def test_mac():
 
     assert results[
         'query_name'] == 'Flowers wrt Pleasant 5 , Pleasant 9, Unpleasant 5 and Unpleasant 9'
+    assert isinstance(results['result'], (np.float32, np.float64, float))
+
+
+def test_ect():
+    weat_word_set = load_weat()
+    model = WordEmbeddingModel(load_weat_w2v(), 'weat_w2v', '')
+
+    ect = ECT()
+    query = Query([weat_word_set['flowers'], weat_word_set['insects']],
+                  [weat_word_set['pleasant_5']], ['Flowers', 'Insects'],
+                  ['Pleasant'])
+    results = ect.run_query(query, model)
+
+    assert results['query_name'] == 'Flowers and Insects wrt Pleasant'
     assert isinstance(results['result'], (np.float32, np.float64, float))


### PR DESCRIPTION
Good day everyone!
First of all, thank you for the nice framework!

This PR adds an implementation for the "Embedding Coherence Test" metric. The metric was originally proposed in [1] and the implementation published in [2]. This implementation fixes some errors of the original implementation and adapts it to be compatible with this framework.

I tried my best to add references, documentation and tests similar to the other implemented metrics. Please let me know if anything needs to be changed.

[1]: Dev, S., & Phillips, J. (2019, April). Attenuating Bias in Word vectors.
[2]: https://github.com/sunipa/Attenuating-Bias-in-Word-Vec