### PR TITLE
fix vocab so -> son

### DIFF
--- a/wefe/datasets/data/WEAT.json
+++ b/wefe/datasets/data/WEAT.json
@@ -359,7 +359,7 @@
     "he",
     "him",
     "his",
-    "so"
+    "son"
   ],
   "female_terms": [
     "female",


### PR DESCRIPTION
Find a mistake in WEAT.json: 'so' in 'male_terms' should be 'son'. 