### PR TITLE
feature: Add dataset fetch retry and update tests with new word sets references

### DIFF
--- a/docs/user_guide/measurement_user_guide.rst
+++ b/docs/user_guide/measurement_user_guide.rst
@@ -309,7 +309,7 @@ names with respect to pleasant and unpleasant attributes.
 
     ethnicity_query = Query(
         [word_sets["european_american_names_5"], word_sets["african_american_names_5"]],
-        [word_sets["pleasant_5"], word_sets["unpleasant_5"]],
+        [word_sets["pleasant_5"], word_sets["unpleasant_5a"]],
         ["European american names", "African american names"],
         ["Pleasant", "Unpleasant"],
     )
@@ -1265,7 +1265,7 @@ Ethnicity Bias Model Ranking
     # define the queries
     ethnicity_query_1 = Query(
         [word_sets["european_american_names_5"], word_sets["african_american_names_5"]],
-        [word_sets["pleasant_5"], word_sets["unpleasant_5"]],
+        [word_sets["pleasant_5"], word_sets["unpleasant_5a"]],
         ["European Names", "African Names"],
         ["Pleasant", "Unpleasant"],
     )

--- a/docs/user_guide/mitigation_user_guide.rst
+++ b/docs/user_guide/mitigation_user_guide.rst
@@ -281,7 +281,7 @@ Next, we measure the gender bias exposed by query 2 (Male Names and Female Names
 
     gender_query_2 = Query(
         [weat_wordset["male_names"], weat_wordset["female_names"]],
-        [weat_wordset["pleasant_5"], weat_wordset["unpleasant_5"]],
+        [weat_wordset["pleasant_5"], weat_wordset["unpleasant_5a"]],
         ["Male Names", "Female Names"],
         ["Pleasant", "Unpleasant"],
     )
@@ -433,7 +433,7 @@ equalized.
 
     gender_query_2 = Query(
         [weat_wordset["male_names"], weat_wordset["female_names"]],
-        [weat_wordset["pleasant_5"], weat_wordset["unpleasant_5"]],
+        [weat_wordset["pleasant_5"], weat_wordset["unpleasant_5a"]],
         ["Male Names", "Female Names"],
         ["Pleasant", "Unpleasant"],
     )

--- a/tests/debias/conftest.py
+++ b/tests/debias/conftest.py
@@ -116,7 +116,7 @@ def gender_query_1(weat_wordsets: dict[str, list[str]]) -> Query:
     """
     query = Query(
         [weat_wordsets["male_names"], weat_wordsets["female_names"]],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["Male Names", "Female Names"],
         ["Pleasant", "Unpleasant"],
     )
@@ -202,9 +202,9 @@ def ethnicity_query_1(weat_wordsets: dict[str, list[str]]) -> Query:
             weat_wordsets["european_american_names_5"],
             weat_wordsets["african_american_names_5"],
         ],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["european_american_names_5", "african_american_names_5"],
-        ["pleasant_5", "unpleasant_5"],
+        ["pleasant_5", "unpleasant_5a"],
     )
     return query
 
@@ -226,8 +226,8 @@ def control_query_1(weat_wordsets: dict[str, list[str]]) -> Query:
     """
     query = Query(
         [weat_wordsets["flowers"], weat_wordsets["insects"]],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["flowers", "insects"],
-        ["pleasant_5", "unpleasant_5"],
+        ["pleasant_5", "unpleasant_5a"],
     )
     return query

--- a/tests/debias/test_double_hard_debias.py
+++ b/tests/debias/test_double_hard_debias.py
@@ -170,7 +170,7 @@ def test_double_hard_debias_checks(
 #     )
 
 #     targets = weat_wordsets["male_names"] + weat_wordsets["female_names"]
-#     attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5"]
+#     attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5a"]
 #     ignore = targets + attributes
 
 #     gender_debiased_w2v = dhd.fit(

--- a/tests/debias/test_half_sibling_regression.py
+++ b/tests/debias/test_half_sibling_regression.py
@@ -108,7 +108,7 @@ def test_half_sibling_regression_ignore_param(
     )
 
     targets = weat_wordsets["male_names"] + weat_wordsets["female_names"]
-    attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5"]
+    attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5a"]
     ignore = targets + attributes
 
     gender_debiased_w2v = hsr.fit(model, definitional_words=gender_specific).transform(

--- a/tests/debias/test_hard_debias.py
+++ b/tests/debias/test_hard_debias.py
@@ -148,7 +148,7 @@ def test_hard_debias_ignore_param(
     # this implies that neither of these words should be subjected to debias and
     # therefore, both queries when executed with weat should return the same score.
     targets = weat_wordsets["male_names"] + weat_wordsets["female_names"]
-    attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5"]
+    attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5a"]
     ignore = targets + attributes
 
     gender_debiased_w2v = hd.fit(

--- a/tests/debias/test_multiclass_hard_debias.py
+++ b/tests/debias/test_multiclass_hard_debias.py
@@ -188,7 +188,7 @@ def test_multiclass_hard_debias_ignore_param(
     # this implies that neither of these words should be subjected to debias and
     # therefore, both queries when executed with weat should return the same score.
     targets = weat_wordsets["male_names"] + weat_wordsets["female_names"]
-    attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5"]
+    attributes = weat_wordsets["pleasant_5"] + weat_wordsets["unpleasant_5a"]
     ignore = targets + attributes
 
     gender_debiased_w2v = mhd.fit(

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -72,7 +72,7 @@ def query_2t2a_1(weat_wordsets: dict[str, list[str]]) -> Query:
     """
     query = Query(
         [weat_wordsets["flowers"], weat_wordsets["insects"]],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["Flowers", "Insects"],
         ["Pleasant", "Unpleasant"],
     )
@@ -87,7 +87,7 @@ def query_3t2a_1(weat_wordsets: dict[str, list[str]]) -> Query:
             weat_wordsets["insects"],
             weat_wordsets["instruments"],
         ],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["Flowers", "Weapons", "Instruments"],
         ["Pleasant", "Unpleasant"],
     )
@@ -104,7 +104,7 @@ def query_4t2a_1(weat_wordsets: dict[str, list[str]]) -> Query:
             weat_wordsets["instruments"],
             weat_wordsets["weapons"],
         ],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["Flowers", "Insects", "Instruments", "Weapons"],
         ["Pleasant", "Unpleasant"],
     )
@@ -119,7 +119,7 @@ def query_1t4_1(weat_wordsets: dict[str, list[str]]) -> Query:
         [
             weat_wordsets["pleasant_5"],
             weat_wordsets["pleasant_9"],
-            weat_wordsets["unpleasant_5"],
+            weat_wordsets["unpleasant_5a"],
             weat_wordsets["unpleasant_9"],
         ],
         ["Flowers"],
@@ -144,7 +144,7 @@ def query_2t1a_lost_vocab_1(weat_wordsets: dict[str, list[str]]) -> Query:
 def query_2t2a_lost_vocab_1(weat_wordsets: dict[str, list[str]]) -> Query:
     query = Query(
         [["bla", "asd"], weat_wordsets["insects"]],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["Flowers", "Insects"],
         ["Pleasant", "Unpleasant"],
     )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -132,7 +132,7 @@ def test_load_weat() -> None:
         "flowers",
         "insects",
         "pleasant_5",
-        "unpleasant_5",
+        "unpleasant_5a",
         "instruments",
         "weapons",
         "european_american_names_5",

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -46,7 +46,7 @@ def query_2t2a_1(weat_wordsets: dict[str, list[str]]) -> Query:
     """
     query = Query(
         [weat_wordsets["flowers"], weat_wordsets["insects"]],
-        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5"]],
+        [weat_wordsets["pleasant_5"], weat_wordsets["unpleasant_5a"]],
         ["Flowers", "Insects"],
         ["Pleasant", "Unpleasant"],
     )
@@ -89,7 +89,7 @@ def query_2t2a_uppercase(weat_wordsets: dict[str, list[str]]) -> Query:
         ],
         [
             [s.upper() for s in weat_wordsets["pleasant_5"]],
-            [s.upper() for s in weat_wordsets["unpleasant_5"]],
+            [s.upper() for s in weat_wordsets["unpleasant_5a"]],
         ],
         ["Flowers", "Insects"],
         ["Pleasant", "Unpleasant"],
@@ -583,7 +583,7 @@ def test_get_embeddings_from_query(
         weat_wordsets["flowers"],
         weat_wordsets["insects"],
         weat_wordsets["pleasant_5"],
-        weat_wordsets["unpleasant_5"],
+        weat_wordsets["unpleasant_5a"],
     )
 
     word_vectors = model.wv
@@ -635,7 +635,7 @@ def test_get_embeddings_from_query_oov_warns(
         weat_wordsets["flowers"],
         weat_wordsets["insects"],
         weat_wordsets["pleasant_5"],
-        weat_wordsets["unpleasant_5"],
+        weat_wordsets["unpleasant_5a"],
     )
 
     flowers_with_oov = flowers + ["aaa", "bbb"]
@@ -667,7 +667,7 @@ def test_get_embeddings_from_query_with_lower_preprocessor(
         weat_wordsets["flowers"],
         weat_wordsets["insects"],
         weat_wordsets["pleasant_5"],
-        weat_wordsets["unpleasant_5"],
+        weat_wordsets["unpleasant_5a"],
     )
 
     embeddings = get_embeddings_from_query(
@@ -706,7 +706,7 @@ def test_get_embeddings_from_query_with_two_preprocessors(
         weat_wordsets["flowers"],
         weat_wordsets["insects"],
         weat_wordsets["pleasant_5"],
-        weat_wordsets["unpleasant_5"],
+        weat_wordsets["unpleasant_5a"],
     )
     embeddings = get_embeddings_from_query(
         model, query_2t2a_uppercase, preprocessors=[{}, {"lowercase": True}]
@@ -741,7 +741,7 @@ def test_get_embeddings_from_query_lost_threshold(
         weat_wordsets["flowers"],
         weat_wordsets["insects"],
         weat_wordsets["pleasant_5"],
-        weat_wordsets["unpleasant_5"],
+        weat_wordsets["unpleasant_5a"],
     )
 
     # with lost vocabulary threshold.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -78,7 +78,7 @@ def test_create_query() -> None:
     flowers = weat_wordsets["flowers"]
     insects = weat_wordsets["insects"]
     pleasant = weat_wordsets["pleasant_5"]
-    unpleasant = weat_wordsets["unpleasant_5"]
+    unpleasant = weat_wordsets["unpleasant_5a"]
 
     # create a query using the word sets:
     query = Query(
@@ -108,7 +108,7 @@ def test_eq() -> None:
     weapons = weat["weapons"]
     pleasant_1 = weat["pleasant_5"]
     pleasant_2 = weat["pleasant_9"]
-    unpleasant_1 = weat["unpleasant_5"]
+    unpleasant_1 = weat["unpleasant_5a"]
     unpleasant_2 = weat["unpleasant_9"]
 
     query = Query([flowers, insects], [pleasant_1, unpleasant_1])
@@ -266,7 +266,7 @@ def test_generate_query_name() -> None:
 
     query = Query(
         [weat_word_set["flowers"], weat_word_set["instruments"]],
-        [weat_word_set["pleasant_5"], weat_word_set["unpleasant_5"]],
+        [weat_word_set["pleasant_5"], weat_word_set["unpleasant_5a"]],
         ["Flowers", "Instruments"],
         ["Pleasant", "Unpleasant"],
     )
@@ -280,7 +280,7 @@ def test_generate_query_name() -> None:
             weat_word_set["weapons"],
             weat_word_set["insects"],
         ],
-        [weat_word_set["pleasant_5"], weat_word_set["unpleasant_5"]],
+        [weat_word_set["pleasant_5"], weat_word_set["unpleasant_5a"]],
         ["Flowers", "Instruments", "Weapons", "Insects"],
         ["Pleasant", "Unpleasant"],
     )
@@ -297,7 +297,7 @@ def test_generate_query_name() -> None:
             weat_word_set["weapons"],
             weat_word_set["insects"],
         ],
-        [weat_word_set["pleasant_5"], weat_word_set["unpleasant_5"]],
+        [weat_word_set["pleasant_5"], weat_word_set["unpleasant_5a"]],
     )
 
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,14 +62,14 @@ def queries_and_models():
     # Create ethnicity queries
     test_query_1 = Query(
         [word_sets["insects"], word_sets["flowers"]],
-        [word_sets["pleasant_5"], word_sets["unpleasant_5"]],
+        [word_sets["pleasant_5"], word_sets["unpleasant_5a"]],
         ["Flowers", "Insects"],
         ["Pleasant", "Unpleasant"],
     )
 
     test_query_2 = Query(
         [word_sets["weapons"], word_sets["instruments"]],
-        [word_sets["pleasant_5"], word_sets["unpleasant_5"]],
+        [word_sets["pleasant_5"], word_sets["unpleasant_5a"]],
         ["Instruments", "Weapons"],
         ["Pleasant", "Unpleasant"],
     )


### PR DESCRIPTION
This pull request updates several queries and tests to replace the `unpleasant_5` word set with a new `unpleasant_5a` word set. Additionally, it introduces a new `_retry_request` function with comprehensive test coverage for retrying network requests. Below is a breakdown of the most important changes grouped by theme:

### Query Updates:
* Updated multiple queries in `docs/user_guide/measurement_user_guide.rst` and `docs/user_guide/mitigation_user_guide.rst` to use `unpleasant_5a` instead of `unpleasant_5` for bias measurements. [[1]](diffhunk://#diff-427056a12b94951897ffb77166f31a8841e913291161472cd5f5451f044e7631L312-R312) [[2]](diffhunk://#diff-427056a12b94951897ffb77166f31a8841e913291161472cd5f5451f044e7631L1268-R1268) [[3]](diffhunk://#diff-899718ddf99b96997f960bab8687fdfcdcace0b4290dbce423bdd236e9fc441cL284-R284) [[4]](diffhunk://#diff-899718ddf99b96997f960bab8687fdfcdcace0b4290dbce423bdd236e9fc441cL436-R436)

### Test Updates:
* Updated test fixtures in `tests/debias/conftest.py` and `tests/metrics/conftest.py` to reflect the change from `unpleasant_5` to `unpleasant_5a` in various queries. [[1]](diffhunk://#diff-babf6a1dc1d621060fb213953533fa24732a992b8f408c1a23b013511d8a6ad8L119-R119) [[2]](diffhunk://#diff-babf6a1dc1d621060fb213953533fa24732a992b8f408c1a23b013511d8a6ad8L205-R207) [[3]](diffhunk://#diff-46bd42a08ee8419ab1df4152cfa52578fb3be4bb7c8f8d21e4b5a1059937a0a1L75-R75) [[4]](diffhunk://#diff-46bd42a08ee8419ab1df4152cfa52578fb3be4bb7c8f8d21e4b5a1059937a0a1L90-R90)
* Updated test cases in `tests/debias` and `tests/test_preprocessing.py` to ensure compatibility with the new `unpleasant_5a` word set. [[1]](diffhunk://#diff-e0723d1d507b11dfde5e7e1743df7e2d01836afc28f6066f4e8bf17eee2f677dL173-R173) [[2]](diffhunk://#diff-a8304ceca59ac252e8069fa65fc1dbea4a456c192f19850524cfa619cb646a0cL111-R111) [[3]](diffhunk://#diff-88a76cb9a5106233fb998861295ace7337171316d0966361b31dd2ff59ce2842L586-R586) [[4]](diffhunk://#diff-88a76cb9a5106233fb998861295ace7337171316d0966361b31dd2ff59ce2842L709-R709)

### New Retry Functionality:
* Added `_retry_request` function in `tests/test_datasets.py` to handle retries for network requests, including support for exponential backoff and handling specific exceptions like HTTP 429 (rate limit) and timeout errors.
* Added a comprehensive suite of tests for `_retry_request` to validate its behavior under various scenarios, such as success on first attempt, rate limit errors, timeout errors, and non-retryable HTTP errors.

### Dataset Updates:
* Updated dataset-related tests in `tests/test_datasets.py` to include the new `unpleasant_5a` and `unpleasant_5b` word sets for validation.

These changes ensure consistency across the codebase for the updated word set and enhance the robustness of network request handling.