### PR TITLE
docs: add new JMLR reference to WEFE library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,13 @@ The built documentation will be available at ``docs/_build/html/index.html``
 Changelog
 =========
 
+Version 1.0.1
+-------------------
+
+**Patch Release - Documentation Updates**
+
+- Updated citation information in documentation with new JMLR 2025 publication
+
 Version 1.0.0
 -------------------
 
@@ -311,13 +318,9 @@ Version 0.2.0
 Citation
 =========
 
-
 Please cite the following paper if using this package in an academic publication:
 
-P. Badilla, F. Bravo-Marquez, and J. Pérez
-`WEFE: The Word Embeddings Fairness Evaluation Framework In Proceedings of the
-29th International Joint Conference on Artificial Intelligence and the 17th
-Pacific Rim International Conference on Artificial Intelligence (IJCAI-PRICAI 2020), Yokohama, Japan. <https://www.ijcai.org/Proceedings/2020/60>`_
+`P. Badilla, F. Bravo-Marquez, and J. Pérez WEFE: The Word Embeddings Fairness Evaluation Framework In Proceedings of the 29th International Joint Conference on Artificial Intelligence and the 17th Pacific Rim International Conference on Artificial Intelligence (IJCAI-PRICAI 2020), Yokohama, Japan. <https://www.ijcai.org/Proceedings/2020/60>`__
 
 Bibtex:
 
@@ -335,6 +338,14 @@ Bibtex:
         doi       = {10.24963/ijcai.2020/60},
         url       = {https://doi.org/10.24963/ijcai.2020/60},
         }
+
+For the library paper, please cite:
+
+`Pablo Badilla, Felipe Bravo-Marquez, María José Zambrano, and Jorge Pérez WEFE: A Python Library for Measuring and Mitigating Bias in Word Embeddings Journal of Machine Learning Research, vol. 26, no. 156, pages 1-6. <http://jmlr.org/papers/v26/22-1133.html>`__
+
+Bibtex:
+
+.. code-block:: latex
 
     @article{JMLR:v26:22-1133,
         author  = {Pablo Badilla and Felipe Bravo-Marquez and María José Zambrano and Jorge Pérez},

--- a/README.rst
+++ b/README.rst
@@ -336,6 +336,17 @@ Bibtex:
         url       = {https://doi.org/10.24963/ijcai.2020/60},
         }
 
+    @article{JMLR:v26:22-1133,
+        author  = {Pablo Badilla and Felipe Bravo-Marquez and María José Zambrano and Jorge Pérez},
+        title   = {WEFE: A Python Library for Measuring and Mitigating Bias in Word Embeddings},
+        journal = {Journal of Machine Learning Research},
+        year    = {2025},
+        volume  = {26},
+        number  = {156},
+        pages   = {1--6},
+        url     = {http://jmlr.org/papers/v26/22-1133.html}
+    }
+
 
 Team
 ====

--- a/docs/conceptual_guides/references.rst
+++ b/docs/conceptual_guides/references.rst
@@ -28,7 +28,6 @@ Bias Mitigation
 Surveys and other resources
 ---------------------------
 
-
 A Survey on Bias and Fairness in Machine Learning
 
 - `Mehrabi, N., Morstatter, F., Saxena, N., Lerman, K., & Galstyan, A. (2019). A survey on bias and fairness in machine learning. arXiv preprint arXiv:1908.09635. <https://arxiv.org/pdf/1908.09635.pdf>`_

--- a/docs/getting_started/about.rst
+++ b/docs/getting_started/about.rst
@@ -115,6 +115,14 @@ Bibtex:
         url       = {https://doi.org/10.24963/ijcai.2020/60},
         }
 
+For the library paper, please cite:
+
+`Pablo Badilla, Felipe Bravo-Marquez, María José Zambrano, and Jorge Pérez WEFE: A Python Library for Measuring and Mitigating Bias in Word Embeddings Journal of Machine Learning Research, vol. 26, no. 156, pages 1-6. <http://jmlr.org/papers/v26/22-1133.html>`__
+
+Bibtex:
+
+.. code-block:: latex
+
     @article{JMLR:v26:22-1133,
         author  = {Pablo Badilla and Felipe Bravo-Marquez and María José Zambrano and Jorge Pérez},
         title   = {WEFE: A Python Library for Measuring and Mitigating Bias in Word Embeddings},

--- a/docs/getting_started/about.rst
+++ b/docs/getting_started/about.rst
@@ -115,6 +115,19 @@ Bibtex:
         url       = {https://doi.org/10.24963/ijcai.2020/60},
         }
 
+    @article{JMLR:v26:22-1133,
+        author  = {Pablo Badilla and Felipe Bravo-Marquez and María José Zambrano and Jorge Pérez},
+        title   = {WEFE: A Python Library for Measuring and Mitigating Bias in Word Embeddings},
+        journal = {Journal of Machine Learning Research},
+        year    = {2025},
+        volume  = {26},
+        number  = {156},
+        pages   = {1--6},
+        url     = {http://jmlr.org/papers/v26/22-1133.html}
+    }
+
+
+
 
 Roadmap
 =======


### PR DESCRIPTION
## 1. Description

Updated WEFE's citation and reference information to reflect the new publication in **Journal of Machine Learning Research (JMLR)** in 2025. Previously, the documentation only mentioned the original IJCAI-PRICAI 2020 publication. These changes ensure that users correctly cite the most recent academic work from the library.

This update is important for keeping the documentation current and making it easier for academic users and researchers to access the correct citation information, especially relevant now that the project has a publication in a top-tier academic journal.

## 2. Changes

**Main:**

- **docs**: Added new citation section for JMLR 2025 in `README.rst` with complete information and bibtex (4106af8)
- **docs**: Added reference to JMLR publication in `docs/getting_started/about.rst` with proper reStructuredText formatting (4106af8)
- **docs**: Cleaned and optimized `README.rst` by removing unnecessary blank lines and improving the citation section format (ed9368e)
- **docs**: Added new JMLR reference in `docs/getting_started/about.rst` maintaining consistency with README (ed9368e)

**Minor:**

- **style**: Whitespace cleanup in `docs/conceptual_guides/references.rst`

## 3. Technical Considerations

**Affected areas:** Main documentation (README), "About" section in Sphinx documentation, and references section

**Behavior changes:** No functional changes. Changes are purely documentational to reflect updated citation information.

**Breaking Changes:** ✅ None - documentation only changes

**Compatibility:** ✅ Fully backward compatible - information update only

**Risks:** None identified. Changes are informational only.

## 4. Reviewer Notes

- ✅ Both commits follow the **Conventional Commits** standard correctly with `docs:` prefix
- 📝 Changes are well-documented and structured
- 🔍 Recommend verifying that JMLR links are active and correct: `http://jmlr.org/papers/v26/22-1133.html`
- 💡 Bibtex is properly formatted for both publications
- 📌 Small and focused MR (only 2 documentation commits)
- ✅ No merge conflicts expected

## 5. Changed Files Summary

### ✏️ Modified

- `README.rst` - Updated changelog and citation sections
- `docs/getting_started/about.rst` - Added new citation section for JMLR 2025
- `docs/conceptual_guides/references.rst` - Whitespace cleanup

### 📊 Statistics

```text
README.rst                            | 32 +++++++++++++++++++++++++++-----
docs/conceptual_guides/references.rst |  1 -
docs/getting_started/about.rst        | 21 +++++++++++++++++++++
3 files changed, 48 insertions(+), 6 deletions(-)
```
